### PR TITLE
Prepend currency code to label to allow searching by currency code

### DIFF
--- a/resources/assets/js/views/settings/Preferences.vue
+++ b/resources/assets/js/views/settings/Preferences.vue
@@ -14,6 +14,7 @@
             <base-select
               v-model="formData.currency"
               :options="currencies"
+              :custom-label="currencyNameWithCode"
               :class="{'error': $v.formData.currency.$error }"
               :searchable="true"
               :show-labels="false"
@@ -179,6 +180,9 @@ export default {
     this.getDiscountSettings()
   },
   methods: {
+    currencyNameWithCode ({name, code}) {
+      return `${code} - ${name}`
+    },
     ...mapActions('currency', [
       'setDefaultCurrency'
     ]),

--- a/resources/assets/js/views/wizard/Settings.vue
+++ b/resources/assets/js/views/wizard/Settings.vue
@@ -11,6 +11,7 @@
             v-model="settingData.currency"
             :class="{'error': $v.settingData.currency.$error }"
             :options="currencies"
+            :custom-label="currencyNameWithCode"
             :searchable="true"
             :show-labels="false"
             :placeholder="$t('settings.currencies.select_currency')"
@@ -150,6 +151,9 @@ export default {
     this.getOnboardingData()
   },
   methods: {
+    currencyNameWithCode ({name, code}) {
+      return `${code} - ${name}`
+    },
     ...mapActions('auth', [
       'loginOnBoardingUser'
     ]),


### PR DESCRIPTION
This PR improves the select input that allows users to choose a currency by appending the currency code to the label. This allows users to search a currency by code instead of name.

Both the preferences page and the on-boarding wizard inputs are concerned.

![currency-code](https://user-images.githubusercontent.com/649677/70654808-57dc2880-1c57-11ea-9752-afdedbb9e2ee.gif)
