### PR TITLE
Removed a space that forced apache to send the wrong headers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 
 return [
 


### PR DESCRIPTION
In `config/app.php` there was a space at the start of the file.

This caused `headers_sent()` to return true and also breaks any attempts to set a `Content-Type` header later in execution, which in turn causes the issue seen in https://github.com/bytefury/crater/issues/14

I have no idea why this is an issue in some versions of Apache (or your web server of choice) and not others, works fine in Ubuntu 19.04 for me but breaks in CentOS 7.7.

Simply removing the space fixes the issue.