### PR TITLE
Add missing currency code to customer create/edit form

### DIFF
--- a/resources/assets/js/views/customers/Create.vue
+++ b/resources/assets/js/views/customers/Create.vue
@@ -61,6 +61,7 @@
                 <base-select
                   v-model="currency"
                   :options="currencies"
+                  :custom-label="currencyNameWithCode"
                   :allow-empty="false"
                   :searchable="true"
                   :show-labels="false"
@@ -435,6 +436,9 @@ export default {
     }
   },
   methods: {
+    currencyNameWithCode ({name, code}) {
+      return `${code} - ${name}`
+    },
     ...mapActions('customer', [
       'addCustomer',
       'fetchCustomer',


### PR DESCRIPTION
In my previous PR https://github.com/bytefury/crater/pull/43, it forgot to add the functionality to the customer create/edit form. This new PR addresses that. Hopefully I did not miss another one.