### PR TITLE
Removed JSON SQL datatype, Replaced with TEXT Type

### DIFF
--- a/database/migrations/2019_09_14_120124_create_media_table.php
+++ b/database/migrations/2019_09_14_120124_create_media_table.php
@@ -20,9 +20,9 @@ class CreateMediaTable extends Migration
             $table->string('mime_type')->nullable();
             $table->string('disk');
             $table->unsignedInteger('size');
-            $table->json('manipulations');
-            $table->json('custom_properties');
-            $table->json('responsive_images');
+            $table->text('manipulations');
+            $table->text('custom_properties');
+            $table->text('responsive_images');
             $table->unsignedInteger('order_column')->nullable();
             $table->nullableTimestamps();
         });


### PR DESCRIPTION
The JSON SQL datatype is not supported in some of the SQL servers (i.e. 5.6.44). Replaced it with TEXT datatype.