### PR TITLE
Fixed problem estimate on convert to Invoice

### DIFF
--- a/app/Http/Controllers/EstimatesController.php
+++ b/app/Http/Controllers/EstimatesController.php
@@ -421,11 +421,14 @@ class EstimatesController extends Controller
                 'discount_per_item',
                 $request->header('company')
             ) : 'NO';
+        
+        $invoice_prefix = CompanySetting::getSetting('invoice_prefix', $request->header('company'));
+        $nextInvoiceNumber = Invoice::getNextInvoiceNumber($invoice_prefix);
 
         $invoice = Invoice::create([
             'invoice_date' => $invoice_date,
             'due_date' => $due_date,
-            'invoice_number' => "INV-".Invoice::getNextInvoiceNumber(),
+            'invoice_number' => $nextInvoiceNumber,
             'reference_number' => $estimate->reference_number,
             'user_id' => $estimate->user_id,
             'company_id' => $request->header('company'),


### PR DESCRIPTION
Previously when the "Convert to Invoice" button was pressed, an error was thrown:
```
Too few arguments to function Crater\Invoice::getNextInvoiceNumber(), 0 passed in /app/Http/Controllers/EstimatesController.php
```

This is now fixed.