### PR TITLE
Fix case sensitive PostgreSQL bug

### DIFF
--- a/app/Address.php
+++ b/app/Address.php
@@ -7,8 +7,8 @@ use Crater\Country;
 
 class Address extends Model
 {
-    const BILLING_TYPE = 'BILLING';
-    const SHIPPING_TYPE = 'SHIPPING';
+    const BILLING_TYPE = 'billing';
+    const SHIPPING_TYPE = 'shipping';
 
     protected $fillable = [
         'name',


### PR DESCRIPTION
There was a bug with the addresses when the application was used with PostgreSQL, because this is case-sensitive and while the constants were written in upper case, they were saved in lower case.
I fixed it by changing the value of the constants to lowercase, which are used only once.