### PR TITLE
Fixed small bug that might occur when an expense is updated

### DIFF
--- a/resources/assets/js/views/expenses/Create.vue
+++ b/resources/assets/js/views/expenses/Create.vue
@@ -321,7 +321,7 @@ export default {
       data.append('expense_category_id', this.formData.expense_category_id)
       data.append('expense_date',  moment(this.formData.expense_date).format('DD/MM/YYYY'))
       data.append('amount', (this.formData.amount))
-      data.append('notes', this.formData.notes)
+      data.append('notes', this.formData.notes ? this.formData.notes : '')
 
       if (this.isEdit) {
         this.isLoading = true


### PR DESCRIPTION
Previoulsy a string with contents "null" is transmitted and saved to the database when updating an expense with an empty note. This fix prevents that.
Please note that this fix still needs to be compiled with npm.