### PR TITLE
Fix long names in the first template

### DIFF
--- a/resources/views/app/pdf/invoice/invoice1.blade.php
+++ b/resources/views/app/pdf/invoice/invoice1.blade.php
@@ -153,8 +153,12 @@
             text-align: right;
         }
         .bill-add {
-            width:45%;
+            display: table;
             padding: 0px 0 0 0px;
+        }
+
+        .bill-add > div {
+            display: table-cell;
         }
 
         /* -------------------------- */


### PR DESCRIPTION
Currently some long names are "eaten" by the width (45%).
The goal here is to remove the width and replace everything with a display table and table-cell to childs.