### PR TITLE
[Docker] Change MariaDB Docker image from official to linuxserver/mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - crater
 
   db:
-    image: mariadb
+    image: linuxserver/mariadb
     restart: always
     volumes:
       - db:/var/lib/mysql


### PR DESCRIPTION
I was trying to have the docker image run on a Raspberry Pi, and it would _always_ fails because the official MariaDB image from Docker Hub is pretty specify of the supported architecture.

Changing the base image from the official to `linuxserver/mariadb` makes it work on the Raspi (4, at least) as this one supports multiarch without any trouble. I know we want to usually keep away from anything non official, but `linuxserver/mariadb` is updated often, and has a large following, so I'm betting it's safe to use if it's to enable multiarch ! :)

I'll let you decide, of course.