### PR TITLE
[Docker] Modify php and nginx config to change upload file size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 .rnd
 /.expo
 /.vscode
+/docker-compose/db/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     working_dir: /var/www/
     volumes:
       - ./:/var/www
+      - ./docker-compose/php/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini:rw,delegated
     networks:
       - crater
 

--- a/docker-compose/nginx/nginx.conf
+++ b/docker-compose/nginx/nginx.conf
@@ -1,4 +1,5 @@
 server {
+    client_max_body_size 64M;
     listen 80;
     index index.php index.html;
     error_log  /var/log/nginx/error.log;

--- a/docker-compose/php/uploads.ini
+++ b/docker-compose/php/uploads.ini
@@ -1,0 +1,3 @@
+file_uploads = On
+upload_max_filesize = 64M
+post_max_size = 64M


### PR DESCRIPTION
When I successfully did the install with Docker, the first time I saw was that uploading a document in an expense would result in an `HTTP 413` error. Time to change the upload file size !

This PR sets an extra config for php, in `docker-compose/php/uploads.ini` that's bind-mounted to the `app` container.  Then, I added a value to the `docker-compose/nginx/nginx.conf` to reflect the values of the uploads.ini file.

This enables files up to 64M, but anyone could change it to their taste.