### PR TITLE
Fixes #371

### DIFF
--- a/resources/views/app/pdf/invoice/invoice1.blade.php
+++ b/resources/views/app/pdf/invoice/invoice1.blade.php
@@ -215,7 +215,6 @@
 
         .total-display-table {
             border-top: none;
-            box-sizing: border-box;
             page-break-inside: avoid;
             page-break-before: auto;
             page-break-after: auto;

--- a/resources/views/app/pdf/invoice/invoice2.blade.php
+++ b/resources/views/app/pdf/invoice/invoice2.blade.php
@@ -256,7 +256,6 @@
         }
 
         .total-display-table {
-            box-sizing: border-box;
             page-break-inside: avoid;
             page-break-before: auto;
             page-break-after: auto;

--- a/resources/views/app/pdf/invoice/invoice3.blade.php
+++ b/resources/views/app/pdf/invoice/invoice3.blade.php
@@ -185,7 +185,6 @@
 
 
         .total-display-table {
-            box-sizing: border-box;
             page-break-inside: avoid;
             page-break-before: auto;
             page-break-after: auto;


### PR DESCRIPTION
seems box-sizing Property is not supported by DOMPDF. just deleted the css rules so DOMPDF will render the PDFs even if you turn on `config/domdpdf.php 'show_warnings' => true`