### PR TITLE
fix(payments): display the currency in receipts

### DIFF
--- a/resources/views/app/pdf/payment/payment.blade.php
+++ b/resources/views/app/pdf/payment/payment.blade.php
@@ -258,7 +258,7 @@
             color: #595959;
         }
 
-        .total-display-box span {
+        .total-display-box .amount {
             float: right;
             font-weight: bold;
             font-size: 14px;
@@ -336,7 +336,7 @@
     </div>
     <div class="total-display-box">
         <p class="total-display-label">@lang('pdf_payment_amount_received_label')</p>
-        <span>{!! format_money_pdf($payment->amount, $payment->user->currency) !!}</span>
+        <span class="amount">{!! format_money_pdf($payment->amount, $payment->user->currency) !!}</span>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Fixed the currency not being displayed in receipts. The problem there was that the format_money_pdf() will return 
`<span style="font-family: DejaVu Sans;">$</span>xxxxx` 
which means that the float:right was applied to both spans, making the currency symbol to not be visible.

This fixes the issue [357](https://github.com/bytefury/crater/issues/357)

