### PR TITLE
Change payment invoices query

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -33,7 +33,7 @@ class UserFactory extends Factory
             'phone' => $this->faker->phoneNumber,
             'company_id' => User::find(1)->company_id,
             'role' => 'super admin',
-            'password' => Hash::make('secret'),
+            'password' => Hash::make('password'),
             'currency_id' => Currency::first()->id
         ];
     }

--- a/resources/assets/js/views/payments/Create.vue
+++ b/resources/assets/js/views/payments/Create.vue
@@ -522,7 +522,7 @@ export default {
     async fetchCustomerInvoices(userId) {
       let data = {
         customer_id: userId,
-        status: 'UNPAID',
+        status: 'DUE',
       }
       let response = await this.fetchInvoices(data)
       this.invoiceList = response.data.invoices.data


### PR DESCRIPTION
Change create payment invoices query

When creating a New Payment, it would be better to query the DUE
invoices instead of the UNPAID. This way we can create multiple payments
against an partially paid invoice.


        `status: 'DUE',`