### PR TITLE
fix(items): added unit name after quantity in the pdf templates

### DIFF
--- a/app/Models/EstimateItem.php
+++ b/app/Models/EstimateItem.php
@@ -22,7 +22,8 @@ class EstimateItem extends Model
         'discount_val',
         'tax',
         'total',
-        'discount'
+        'discount',
+        'unit_name',
     ];
 
     protected $casts = [

--- a/app/Models/InvoiceItem.php
+++ b/app/Models/InvoiceItem.php
@@ -25,7 +25,8 @@ class InvoiceItem extends Model
         'discount_val',
         'total',
         'tax',
-        'discount'
+        'discount',
+        'unit_name',
     ];
 
     protected $casts = [

--- a/database/migrations/2021_03_03_155223_add_unit_name_to_pdf.php
+++ b/database/migrations/2021_03_03_155223_add_unit_name_to_pdf.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUnitNameToPdf extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->string('unit_name')->nullable()->after('quantity');
+        });
+        Schema::table('estimate_items', function (Blueprint $table) {
+            $table->string('unit_name')->nullable()->after('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table->dropColumn('unit_name');
+        });
+        Schema::table('estimate_items', function (Blueprint $table) {
+            $table->dropColumn('unit_name');
+        });
+    }
+}

--- a/resources/views/app/pdf/estimate/partials/table.blade.php
+++ b/resources/views/app/pdf/estimate/partials/table.blade.php
@@ -34,7 +34,7 @@
                 class="pr-20 text-right item-cell"
                 style="vertical-align: top;"
             >
-                {{$item->quantity}}
+                {{$item->quantity}} @if($item->unit_name) {{$item->unit_name}} @endif
             </td>
             <td
                 class="pr-20 text-right item-cell"

--- a/resources/views/app/pdf/invoice/partials/table.blade.php
+++ b/resources/views/app/pdf/invoice/partials/table.blade.php
@@ -31,7 +31,7 @@
                 class="pr-20 text-right item-cell"
                 style="vertical-align: top;"
             >
-                {{$item->quantity}}
+                {{$item->quantity}} @if($item->unit_name) {{$item->unit_name}} @endif
             </td>
             <td
                 class="pr-20 text-right item-cell"


### PR DESCRIPTION
- Added the unit name in invoices and estimates pdf templates after the quantity where items have a unit set
- This is NOT backwards compatible, meaning the old invoices and estimates will not display the unit_name. in order to have this on older invoices you need to edit the invoices/estimates, remove the item from the invoice and re-add the item(s) and save the invoice.