### PR TITLE
Adjust money format to respect swap_currency_symbol

### DIFF
--- a/database/seeders/CurrenciesTableSeeder.php
+++ b/database/seeders/CurrenciesTableSeeder.php
@@ -37,7 +37,8 @@ class CurrenciesTableSeeder extends Seeder
                 'symbol' => '€',
                 'precision' => '2',
                 'thousand_separator' => '.',
-                'decimal_separator' => ','
+                'decimal_separator' => ',',
+                'swap_currency_symbol' => true
             ],
             [
                 'name' => 'South African Rand',

--- a/resources/assets/js/helpers/utilities.js
+++ b/resources/assets/js/helpers/utilities.js
@@ -23,7 +23,7 @@ export default {
 
     amount = amount / 100
 
-    let { precision, decimal_separator, thousand_separator, symbol } = currency
+    let { precision, decimal_separator, thousand_separator, symbol, swap_currency_symbol } = currency
 
     try {
       precision = Math.abs(precision)
@@ -37,19 +37,14 @@ export default {
       let j = i.length > 3 ? i.length % 3 : 0
 
       let moneySymbol = `<span style="font-family: sans-serif">${symbol}</span>`
+      let thousandText = (j ? i.substr(0, j) + thousand_separator : '')
+      let amountText = i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + thousand_separator)
+      let precisionText = (precision ? decimal_separator + Math.abs(amount - i).toFixed(precision).slice(2) : '');
+      let combinedAmountText = negativeSign + thousandText + amountText + precisionText       
 
-      return (
-        moneySymbol +
-        ' ' +
-        negativeSign +
-        (j ? i.substr(0, j) + thousand_separator : '') +
-        i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + thousand_separator) +
-        (precision
-          ? decimal_separator +
-            Math.abs(amount - i)
-              .toFixed(precision)
-              .slice(2)
-          : '')
+      return (swap_currency_symbol 
+        ? combinedAmountText + ' ' + moneySymbol 
+        : moneySymbol + ' ' + combinedAmountText
       )
     } catch (e) {
       console.log(e)
@@ -68,7 +63,7 @@ export default {
 
     amount = amount / 100
 
-    let { precision, decimal_separator, thousand_separator, symbol } = currency
+    let { precision, decimal_separator, thousand_separator, symbol, swap_currency_symbol } = currency
 
     try {
       precision = Math.abs(precision)
@@ -82,19 +77,14 @@ export default {
       let j = i.length > 3 ? i.length % 3 : 0
 
       let moneySymbol = `${symbol}`
+      let thousandText = (j ? i.substr(0, j) + thousand_separator : '')
+      let amountText = i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + thousand_separator)
+      let precisionText = (precision ? decimal_separator + Math.abs(amount - i).toFixed(precision).slice(2) : '');
+      let combinedAmountText = negativeSign + thousandText + amountText + precisionText       
 
-      return (
-        moneySymbol +
-        ' ' +
-        negativeSign +
-        (j ? i.substr(0, j) + thousand_separator : '') +
-        i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + thousand_separator) +
-        (precision
-          ? decimal_separator +
-            Math.abs(amount - i)
-              .toFixed(precision)
-              .slice(2)
-          : '')
+      return (swap_currency_symbol 
+        ? combinedAmountText + ' ' + moneySymbol 
+        : moneySymbol + ' ' + combinedAmountText
       )
     } catch (e) {
       console.log(e)


### PR DESCRIPTION
Adjust money format to respect `swap_currency_symbol`:
![Screenshot_2021 03 20_17h50m45s_007_](https://user-images.githubusercontent.com/1368405/111877723-d79d8a80-89a4-11eb-9191-bb5d2a0d2655.png)

Also places the € symbol after the amount. While there are some countries writing the € before the amount (4 out of 28), most countries don't do that:
https://en.wikipedia.org/wiki/Language_and_the_euro#Written_conventions_for_the_euro_in_the_languages_of_EU_member_states
Hence I switched the position. In the future, there should be an option in the app setting, that allows the user to easily set this on his own (without the need to edit the database entry).

Closes #415 