### PR TITLE
Add user token management endpoints

### DIFF
--- a/app/Http/Controllers/V1/Settings/UserTokensController.php
+++ b/app/Http/Controllers/V1/Settings/UserTokensController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Crater\Http\Controllers\V1\Settings;
+
+use Auth;
+use Crater\Http\Controllers\Controller;
+use Crater\Http\Requests\CreateUserTokenRequest;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class UserTokensController extends Controller
+{
+    public function listUserTokens()
+    {
+        $user = Auth::user();
+        $formatted_tokens = $user->tokens
+            ->map(function($token) {
+                return $this->formatUserToken($token);
+            });
+        return response()->json(['success' => true, 'tokens' => $formatted_tokens]);
+    }
+
+    public function getUserToken(int $token_id)
+    {
+        $user = Auth::user();
+        $token = $user->tokens()
+          ->where('id', $token_id)
+          ->firstOrFail();
+        $formatted_token = $this->formatUserToken($token);
+        return response()->json(['success' => true, 'token' => $formatted_token]);
+    }
+
+    public function createUserToken(CreateUserTokenRequest $request)
+    {
+        $user = Auth::user();
+        $token = $user->createToken($request->token_name);
+        return response()->json(['success' => true, 'token' => $token->plainTextToken]);
+    }
+
+    public function deleteUserToken(int $token_id)
+    {
+        $user = Auth::user();
+        $user->tokens()->where('id', $token_id)->firstOrFail()->delete();
+        return response()->json(['success' => true]);
+    }
+
+    private function formatUserToken(PersonalAccessToken $token)
+    {
+        return [
+          'id' => $token->id,
+          'name' => $token->name,
+          'last_used_at' => $token->last_used_at,
+          'created_at' => $token->created_at,
+          'updated_at' => $token->updated_at,
+        ];
+    }
+}

--- a/app/Http/Requests/CreateUserTokenRequest.php
+++ b/app/Http/Requests/CreateUserTokenRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Crater\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateUserTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'token_name' => [
+                'required',
+                'string',
+            ]
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,6 +53,7 @@ use Crater\Http\Controllers\V1\Settings\GetUserSettingsController;
 use Crater\Http\Controllers\V1\Settings\TaxTypesController;
 use Crater\Http\Controllers\V1\Settings\UpdateCompanySettingsController;
 use Crater\Http\Controllers\V1\Settings\UpdateUserSettingsController;
+use Crater\Http\Controllers\V1\Settings\UserTokensController;
 use Crater\Http\Controllers\V1\Update\CheckVersionController;
 use Crater\Http\Controllers\V1\Update\CopyFilesController;
 use Crater\Http\Controllers\V1\Update\DeleteFilesController;
@@ -302,6 +303,14 @@ Route::prefix('/v1')->group(function () {
         Route::get('/me/settings', GetUserSettingsController::class);
 
         Route::put('/me/settings', UpdateUserSettingsController::class);
+
+        Route::get('/me/tokens', [UserTokensController::class, 'listUserTokens']);
+
+        Route::get('/me/tokens/{token_id}', [UserTokensController::class, 'getUserToken']);
+
+        Route::delete('/me/tokens/{token_id}', [UserTokensController::class, 'deleteUserToken']);
+
+        Route::post('/me/tokens', [UserTokensController::class, 'createUserToken']);
 
         Route::post('/me/upload-avatar', [CompanyController::class, 'uploadAvatar']);
 


### PR DESCRIPTION
This change adds a controller for managing the logged-in user's personal access tokens. These are a feature of Sanctum that is already built-in to Crater, but which hasn't yet been exposed (no database migrations are required etc.).

I just followed the guidance from the [Laravel docs](https://laravel.com/docs/8.x/sanctum#api-token-authentication), but I'm no PHP developer—I'm happy to make any style/organizational changes you suggest.

This capability is useful to me, as I use [beancount](https://github.com/beancount/beancount/) and would like to write a script that syncs my invoices, payments, and expenses recorded in Crater with my beancount ledger.

Since there doesn't seem to be much demand for this otherwise, I didn't look into exposing any of this in the UI. Users who want API access can generate a token manually.

-----

To create an initial token, I used the network tab in my browser's developer tools to "copy as curl" an API request, such as to `/api/v1/me`, then modify it to POST to `/api/v1/me/tokens?token_name=my-token`.

That returns something like:
```json
{"success":true,"token":"5|nDC2oWixWYYBsiD7P5gnkTRSky0OnKNj4DlQWal8"}
```

And the provided token can be subsequently used as a bearer token for further requests:
```
$ curl -H 'Authorization: Bearer 5|nDC2oWixWYYBsiD7P5gnkTRSky0OnKNj4DlQWal8' -H 'Accept: application/json' http://localhost:8080/api/v1/me
{"user":{"id":1,"name":"Foo Bar","email":"foo@example.com", ...}
```
