### PR TITLE
Delete limit 255 description estimate

### DIFF
--- a/resources/assets/js/views/estimates/ItemSelect.vue
+++ b/resources/assets/js/views/estimates/ItemSelect.vue
@@ -104,15 +104,6 @@ export default {
       loading: false,
     }
   },
-  validations() {
-    return {
-      item: {
-        description: {
-          maxLength: maxLength(255),
-        },
-      },
-    }
-  },
   computed: {
     ...mapGetters('item', ['items']),
   },


### PR DESCRIPTION
There is a limit on the description of the estimate vue which is not necessary.
The field in the database is in TEXT.