### PR TITLE
Add tax column to invoices

### DIFF
--- a/resources/assets/js/plugins/ar.json
+++ b/resources/assets/js/plugins/ar.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "الكمية",
   "pdf_price_label": "السعر",
   "pdf_discount_label": "الخصم",
+  "pdf_tax_label": "ضريبة",
   "pdf_amount_label": "المبلغ المطلوب",
   "pdf_subtotal": "المجموع الفرعي",
   "pdf_total": "الإجمالي",

--- a/resources/assets/js/plugins/de.json
+++ b/resources/assets/js/plugins/de.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Menge",
   "pdf_price_label": "Preis",
   "pdf_discount_label": "Rabatt",
+  "pdf_tax_label": "Steuer",
   "pdf_amount_label": "Summe",
   "pdf_subtotal": "Zwischensumme",
   "pdf_total": "Gesamt",

--- a/resources/assets/js/plugins/en.json
+++ b/resources/assets/js/plugins/en.json
@@ -1178,6 +1178,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "Tax",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/es.json
+++ b/resources/assets/js/plugins/es.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Cantidad",
   "pdf_price_label": "Precio",
   "pdf_discount_label": "Descuento",
+  "pdf_tax_label": "Impuesto",
   "pdf_amount_label": "Cantidad",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/fa.json
+++ b/resources/assets/js/plugins/fa.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "Tax",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/fi.json
+++ b/resources/assets/js/plugins/fi.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Määrä",
   "pdf_price_label": "Hinta",
   "pdf_discount_label": "Alennus",
+  "pdf_tax_label": "ALV",
   "pdf_amount_label": "Yhteensä veroton",
   "pdf_subtotal": "Välisumma",
   "pdf_total": "Yhteensä",

--- a/resources/assets/js/plugins/fr.json
+++ b/resources/assets/js/plugins/fr.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantité",
   "pdf_price_label": "Prix",
   "pdf_discount_label": "Remise",
+  "pdf_tax_label": "Taxe",
   "pdf_amount_label": "Montant",
   "pdf_subtotal": "Total HT",
   "pdf_total": "Total TTC",

--- a/resources/assets/js/plugins/hi.json
+++ b/resources/assets/js/plugins/hi.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "कर",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/it.json
+++ b/resources/assets/js/plugins/it.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantità",
   "pdf_price_label": "Prezzo",
   "pdf_discount_label": "Sconto",
+  "pdf_tax_label": "Imposta",
   "pdf_amount_label": "Ammontare",
   "pdf_subtotal": "Parziale",
   "pdf_total": "Totale",

--- a/resources/assets/js/plugins/ja.json
+++ b/resources/assets/js/plugins/ja.json
@@ -1163,6 +1163,7 @@
     "pdf_quantity_label": "量",
     "pdf_price_label": "価格",
     "pdf_discount_label": "ディスカウント",
+  "pdf_tax_label": "税金",
     "pdf_amount_label": "量",
     "pdf_subtotal": "小計",
     "pdf_total": "合計",

--- a/resources/assets/js/plugins/ko.json
+++ b/resources/assets/js/plugins/ko.json
@@ -1163,6 +1163,7 @@
     "pdf_quantity_label": "수량",
     "pdf_price_label": "가격",
     "pdf_discount_label": "할인",
+  "pdf_tax_label": "세",
     "pdf_amount_label": "양",
     "pdf_subtotal": "소계",
     "pdf_total": "합계",

--- a/resources/assets/js/plugins/lv.json
+++ b/resources/assets/js/plugins/lv.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Daudzums",
   "pdf_price_label": "Cena",
   "pdf_discount_label": "Atlaide",
+  "pdf_tax_label": "Nodoklis",
   "pdf_amount_label": "Summa",
   "pdf_subtotal": "Starpsumma",
   "pdf_total": "Kopā",

--- a/resources/assets/js/plugins/nl.json
+++ b/resources/assets/js/plugins/nl.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Aantal stuks",
   "pdf_price_label": "Prijs",
   "pdf_discount_label": "Korting",
+  "pdf_tax_label": "Belasting",
   "pdf_amount_label": "Bedrag",
   "pdf_subtotal": "Subtotaal",
   "pdf_total": "Totaal",

--- a/resources/assets/js/plugins/pl.json
+++ b/resources/assets/js/plugins/pl.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "Tax",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/pt.json
+++ b/resources/assets/js/plugins/pt.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantidade",
   "pdf_price_label": "Preço",
   "pdf_discount_label": "Desconto",
+  "pdf_tax_label": "Imposto",
   "pdf_amount_label": "Valor",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/ro.json
+++ b/resources/assets/js/plugins/ro.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "Tax",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/ru.json
+++ b/resources/assets/js/plugins/ru.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Кол-во",
   "pdf_price_label": "Цена",
   "pdf_discount_label": "Скидка",
+  "pdf_tax_label": "Налог",
   "pdf_amount_label": "Сумма",
   "pdf_subtotal": "В сумме",
   "pdf_total": "Итого",

--- a/resources/assets/js/plugins/sk.json
+++ b/resources/assets/js/plugins/sk.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Počet",
   "pdf_price_label": "Cena",
   "pdf_discount_label": "Zľava",
+  "pdf_tax_label": "Daň",
   "pdf_amount_label": "Celkom",
   "pdf_subtotal": "Medzisúčet",
   "pdf_total": "Súčet",

--- a/resources/assets/js/plugins/sr.json
+++ b/resources/assets/js/plugins/sr.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Količina",
   "pdf_price_label": "Cena",
   "pdf_discount_label": "Popust",
+  "pdf_tax_label": "Porez",
   "pdf_amount_label": "Iznos",
   "pdf_subtotal": "Osnovica za obračun PDV-a",
   "pdf_total": "Ukupan iznos",

--- a/resources/assets/js/plugins/sv.json
+++ b/resources/assets/js/plugins/sv.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Antal",
   "pdf_price_label": "Kostnad",
   "pdf_discount_label": "Rabatt",
+  "pdf_tax_label": "Moms",
   "pdf_amount_label": "Belopp",
   "pdf_subtotal": "Delsumma",
   "pdf_total": "Summa",

--- a/resources/assets/js/plugins/tr.json
+++ b/resources/assets/js/plugins/tr.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "Vergi",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/assets/js/plugins/vi.json
+++ b/resources/assets/js/plugins/vi.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Định lượng",
   "pdf_price_label": "Giá bán",
   "pdf_discount_label": "Giảm giá",
+  "pdf_tax_label": "Thuế",
   "pdf_amount_label": "Số tiền",
   "pdf_subtotal": "Tổng phụ",
   "pdf_total": "Toàn bộ",

--- a/resources/assets/js/plugins/zh.json
+++ b/resources/assets/js/plugins/zh.json
@@ -1167,6 +1167,7 @@
   "pdf_quantity_label": "Quantity",
   "pdf_price_label": "Price",
   "pdf_discount_label": "Discount",
+  "pdf_tax_label": "Tax",
   "pdf_amount_label": "Amount",
   "pdf_subtotal": "Subtotal",
   "pdf_total": "Total",

--- a/resources/views/app/pdf/invoice/partials/table.blade.php
+++ b/resources/views/app/pdf/invoice/partials/table.blade.php
@@ -7,6 +7,9 @@
         @if($invoice->discount_per_item === 'YES')
         <th class="pl-10 text-right item-table-heading">@lang('pdf_discount_label')</th>
         @endif
+        @if($invoice->tax_per_item === 'YES')
+        <th class="pl-10 text-right item-table-heading">@lang('pdf_tax_label')</th>
+        @endif
         <th class="text-right item-table-heading">@lang('pdf_amount_label')</th>
     </tr>
     @php
@@ -51,6 +54,15 @@
                         @if($item->discount_type === 'percentage')
                             {{$item->discount}}%
                         @endif
+                </td>
+            @endif
+
+            @if($invoice->tax_per_item === 'YES')
+                <td
+                    class="pl-10 text-right item-cell"
+                    style="vertical-align: top;"
+                >
+                    {!! format_money_pdf($item->tax, $invoice->user->currency) !!}
                 </td>
             @endif
 


### PR DESCRIPTION
When an invoice has tax per item enabled, include a tax column so that
it's clear how much tax is being applied to each item.

![image](https://user-images.githubusercontent.com/95053/126486479-a9e290b7-0038-4b87-a830-ed6a0ccf252e.png)