### PR TITLE
HTTPS as Standard

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,10 @@
 
     RewriteEngine On
 
+    #HTTP > HTTPS Redirect
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]


### PR DESCRIPTION
Added the HTTPS Redirect as standard because we live in a world where HTTP is not an option anymore.