### PR TITLE
Adding HTTP Security Headers

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -18,3 +18,10 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 </IfModule>
+
+# HTTP Security Headers
+<IfModule mod_headers.c>
+	Header set X-XSS-Protection "1; mode=block"
+	Header always append X-Frame-Options SAMEORIGIN
+	Header set X-Content-Type-Options nosniff
+</IfModule>


### PR DESCRIPTION
Adding HTTP Security Headers to prevent from XSS, MIME Type Sniffing and against page-framing and click-jacking.

Already tested on my instance:

Before:
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/25208775/127699829-773e0bec-2fdd-4e8c-8c44-4fa9b1c5a300.png">


After:
<img width="1137" alt="Bildschirmfoto 2021-07-30 um 20 59 00" src="https://user-images.githubusercontent.com/25208775/127699715-88393c94-1d8e-4825-a1cf-84e61855d8f9.png">
